### PR TITLE
Hide unused routes in debug_data

### DIFF
--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -830,6 +830,12 @@ pub fn user_node_routes(
         api_keys.clone(),
         cache.clone(),
     ))
+    // .or(address_construction(
+    //     dp,
+    //     routes_pow_info.clone(),
+    //     api_keys.clone(),
+    //     cache.clone(),
+    // ))
     .or(debug_data(
         dp_vec,
         node,
@@ -860,6 +866,13 @@ pub fn storage_node_routes(
         api_keys.clone(),
         cache.clone(),
     )
+    // .or(transactions_by_key(
+    //     dp,
+    //     db.clone(),
+    //     routes_pow_info.clone(),
+    //     api_keys.clone(),
+    //     cache.clone(),
+    // ))
     .or(latest_block(
         dp,
         db.clone(),
@@ -874,6 +887,19 @@ pub fn storage_node_routes(
         api_keys.clone(),
         cache.clone(),
     ))
+    // .or(blocks_by_tx_hashes(
+    //     dp,
+    //     db,
+    //     routes_pow_info.clone(),
+    //     api_keys.clone(),
+    //     cache.clone(),
+    // ))
+    // .or(address_construction(
+    //     dp,
+    //     routes_pow_info.clone(),
+    //     api_keys.clone(),
+    //     cache.clone(),
+    // ))
     .or(debug_data(
         dp_vec,
         node,
@@ -920,6 +946,47 @@ pub fn compute_node_routes(
         api_keys.clone(),
         cache.clone(),
     ))
+    // .or(utxo_addresses(
+    //     dp,
+    //     threaded_calls.clone(),
+    //     routes_pow_info.clone(),
+    //     api_keys.clone(),
+    //     cache.clone(),
+    // ))
+    // .or(address_construction(
+    //     dp,
+    //     routes_pow_info.clone(),
+    //     api_keys.clone(),
+    //     cache.clone(),
+    // ))
+    // .or(pause_nodes(
+    //     dp,
+    //     threaded_calls.clone(),
+    //     routes_pow_info.clone(),
+    //     api_keys.clone(),
+    //     cache.clone(),
+    // ))
+    // .or(resume_nodes(
+    //     dp,
+    //     threaded_calls.clone(),
+    //     routes_pow_info.clone(),
+    //     api_keys.clone(),
+    //     cache.clone(),
+    // ))
+    // .or(update_shared_config(
+    //     dp,
+    //     threaded_calls.clone(),
+    //     routes_pow_info.clone(),
+    //     api_keys.clone(),
+    //     cache.clone(),
+    // ))
+    // .or(get_shared_config(
+    //     dp,
+    //     threaded_calls,
+    //     routes_pow_info.clone(),
+    //     api_keys.clone(),
+    //     cache.clone(),
+    // ))
     .or(debug_data(
         dp_vec,
         node,
@@ -986,6 +1053,12 @@ pub fn miner_node_routes(
         api_keys.clone(),
         cache.clone(),
     ))
+    // .or(address_construction(
+    //     dp,
+    //     routes_pow_info.clone(),
+    //     api_keys.clone(),
+    //     cache.clone(),
+    // ))
     .or(debug_data(
         dp_vec,
         node,
@@ -1026,6 +1099,21 @@ pub fn miner_node_with_user_routes(
         api_keys.clone(),
         cache.clone(),
     ))
+    // .or(make_ip_payment(
+    //     dp,
+    //     db.clone(),
+    //     user_node.clone(),
+    //     routes_pow_info.clone(),
+    //     api_keys.clone(),
+    //     cache.clone(),
+    // ))
+    // .or(request_donation(
+    //     dp,
+    //     user_node.clone(),
+    //     routes_pow_info.clone(),
+    //     api_keys.clone(),
+    //     cache.clone(),
+    // ))
     .or(export_keypairs(
         dp,
         db.clone(),
@@ -1075,6 +1163,12 @@ pub fn miner_node_with_user_routes(
         api_keys.clone(),
         cache.clone(),
     ))
+    // .or(address_construction(
+    //     dp,
+    //     routes_pow_info.clone(),
+    //     api_keys.clone(),
+    //     cache.clone(),
+    // ))
     .or(debug_data(
         dp_vec,
         miner_node,


### PR DESCRIPTION
These routes are within the handler code but have been remove from the available Warp API routes. The functions have not been removed from _routes.rs_ file.

**Miner**
- make_ip_payment
- request_donation
- address_construction (duplicate of payment_address)

**Mempool** 
- address_construction
- pause_nodes
- resume_nodes
- update_shared_config
- get_shared_config
- utxo_addresses

**Storage** 
- check_transaction_presence
- address_construction
- transactions_by_key

It seems _routes.rs_ still has inconsistencies and will need further refactoring.