### PR TITLE
Don't submit failed transactions to the mempool

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -561,6 +561,10 @@ pub async fn post_make_payment(
     .await
     .map_err(|e| map_string_err(r.clone(), e, StatusCode::INTERNAL_SERVER_ERROR))?;
 
+    if !response.success {
+        return r.into_err_internal(ApiErrorType::Generic(response.reason));
+    }
+
     let request = UserRequest::UserApi(UserApiRequest::SendNextPayment);
     if let Err(e) = peer.inject_next_event(peer.local_address(), request) {
         error!("route:make_payment error: {:?}", e);

--- a/src/user.rs
+++ b/src/user.rs
@@ -852,6 +852,8 @@ impl UserNode {
         &mut self,
         mempool_peer: SocketAddr,
     ) -> Result<()> {
+        // TODO: having next_payment as part of the node is error-prone, it would be better to
+        // simply pass the transaction in as an argument
         let (peer, tx) = self.next_payment.take().unwrap();
 
         debug!(


### PR DESCRIPTION
## Description
this prevents a SendNextPayment request from being made if make_payment() fails, thereby avoiding a panic in send_next_payment_to_destinations().

## Changelog

- List the changes to the codebase that this PR introduces

## Type of Change
Please mark the appropriate option by putting an "x" inside the brackets:

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement or optimization
- [ ] Documentation update
- [ ] Other (please specify)

## Checklist
Put an "x" in the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have tested the changes locally and they work as expected.
- [x] I have added necessary documentation or updated existing documentation.
- [x] My code follows the project's coding standards and style guidelines.
- [ ] I have added/updated relevant tests to ensure the changes are properly covered.
- [x] I have checked for and resolved any merge conflicts.
- [x] My commits have clear and descriptive messages.

## Screenshots (if applicable)
If the changes affect the UI or have visual effects, please provide screenshots or GIFs showcasing the changes.

## Additional Context (if applicable)
Add any additional context or information about the changes that may be helpful in understanding the pull request.

## Related Issues (if applicable)
If this pull request is related to any existing issues, please list them here.

## Requested Reviewers
Mention any specific individuals or teams you would like to request a review from.