### PR TITLE
Fix miner panic on GLFW init failure

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+/.idea/
+/.vscode/
+
+/assets/
+/run/
+/src/bin/tls_data/
+/src/db/db/
+/src/wallet/wallet/
+/target/
+*.log


### PR DESCRIPTION
## Description
This fixes a stupid oversight in the OpenGL miner implementation: the default GLFW initialization callback causes a panic on failure, which caused the entire worker thread running the miner to exit prematurely.

## Changelog

- Make GLFW initialization error handling more robust by relaying any errors up to the caller
- Added a `.dockerignore` file configured to ignore the irrelevant scratch files present in a development environment, because sending 7GiB of data to the docker build context seems somewhat excessive and makes stuff significantly slower

## Type of Change
Please mark the appropriate option by putting an "x" inside the brackets:

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement or optimization
- [ ] Documentation update
- [ ] Other (please specify)

## Checklist
Put an "x" in the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have tested the changes locally and they work as expected.
- [x] I have added necessary documentation or updated existing documentation.
- [x] My code follows the project's coding standards and style guidelines.
- [ ] I have added/updated relevant tests to ensure the changes are properly covered.
- [x] I have checked for and resolved any merge conflicts.
- [x] My commits have clear and descriptive messages.

## Screenshots (if applicable)
If the changes affect the UI or have visual effects, please provide screenshots or GIFs showcasing the changes.

## Additional Context (if applicable)
Add any additional context or information about the changes that may be helpful in understanding the pull request.

## Related Issues (if applicable)
If this pull request is related to any existing issues, please list them here.

## Requested Reviewers
Mention any specific individuals or teams you would like to request a review from.