### PR TITLE
Semaphore rate limiting for API; Node worker threading

### DIFF
--- a/src/api/errors.rs
+++ b/src/api/errors.rs
@@ -74,3 +74,8 @@ impl std::fmt::Display for ApiErrorType {
         }
     }
 }
+
+#[derive(Debug)]
+pub struct OverloadedError;
+
+impl warp::reject::Reject for OverloadedError {}

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -1686,12 +1686,14 @@ async fn test_post_fetch_balance() {
     //
     let ks = to_api_keys(Default::default());
     let cache = create_new_cache(CACHE_LIVE_TIME);
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(1));
 
     let filter = routes::fetch_balance(
         &mut dp(),
         mempool.threaded_calls.tx.clone(),
         Default::default(),
         ks,
+        semaphore,
         cache,
     )
     .recover(handle_rejection);
@@ -1877,11 +1879,13 @@ async fn test_post_create_transactions_common(address_version: Option<u64>) {
     let ks = to_api_keys(Default::default());
     let cache = create_new_cache(CACHE_LIVE_TIME);
 
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(1));
     let filter = routes::create_transactions(
         &mut dp(),
         mempool.threaded_calls.tx.clone(),
         Default::default(),
         ks,
+        semaphore,
         cache,
     )
     .recover(handle_rejection);
@@ -2131,12 +2135,14 @@ async fn test_post_create_item_asset_tx_mempool() {
     //
     let ks = to_api_keys(Default::default());
     let cache = create_new_cache(CACHE_LIVE_TIME);
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(1));
 
     let filter = routes::create_item_asset(
         &mut dp(),
         mempool.threaded_calls.tx.clone(),
         Default::default(),
         ks,
+        semaphore,
         cache,
     )
     .recover(handle_rejection);
@@ -2228,11 +2234,13 @@ async fn test_post_create_item_asset_tx_mempool_failure() {
     //
     let ks = to_api_keys(Default::default());
     let cache = create_new_cache(CACHE_LIVE_TIME);
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(1));
     let filter = routes::create_item_asset(
         &mut dp(),
         mempool.threaded_calls.tx.clone(),
         Default::default(),
         ks,
+        semaphore,
         cache,
     )
     .recover(handle_rejection);

--- a/src/bin/node/main.rs
+++ b/src/bin/node/main.rs
@@ -9,7 +9,7 @@ mod pre_launch;
 mod storage;
 mod user;
 
-#[tokio::main]
+#[tokio::main(flavor = "multi_thread", worker_threads = 8)]
 async fn main() {
     tracing_subscriber::fmt::init();
     let matches = clap_app().get_matches();

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -74,6 +74,9 @@ pub const SANC_LIST_TEST: &str = "src/db/sanc_list_test.json";
 /// Default limit on number of internal transactions for a miner node
 pub const INTERNAL_TX_LIMIT: usize = 999;
 
+/// Default limit on the number of concurrent API connections per node
+pub const API_CONCURRENCY_LIMIT: usize = 100;
+
 /// Maximum number of attempts to resend trigger messages before proposing to reset the mining pipeline
 pub const RESEND_TRIGGER_MESSAGES_COMPUTE_LIMIT: usize = 5;
 


### PR DESCRIPTION
## Description
Improves performance of nodes re multiple connections

## Changelog

- Introduces semaphore for connection restriction on mempool nodes
- Adds `worker_thread` handling to a node's `main` function call

## Type of Change
Please mark the appropriate option by putting an "x" inside the brackets:

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement or optimization
- [ ] Documentation update
- [ ] Other (please specify)

## Checklist
Put an "x" in the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have tested the changes locally and they work as expected.
- [ ] I have added necessary documentation or updated existing documentation.
- [x] My code follows the project's coding standards and style guidelines.
- [x] I have added/updated relevant tests to ensure the changes are properly covered.
- [x] I have checked for and resolved any merge conflicts.
- [x] My commits have clear and descriptive messages.