### PR TITLE
Add Health Check Endpoint for Node Types in Handlers and Routes

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,0 +1,6 @@
+use actix_web::{get, HttpResponse, Responder};
+
+#[get("/health_check")]
+pub async fn health_check() -> impl Responder {
+    HttpResponse::Ok().body("Node is alive")
+}

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,0 +1,33 @@
+use actix_web::{web, HttpResponse, Scope};
+
+use crate::handlers;
+
+pub fn user_routes() -> Scope {
+    web::scope("/user")
+        .service(handlers::user_handler)
+        .route("/health", web::get().to(handlers::health_check))
+}
+
+pub fn storage_routes() -> Scope {
+    web::scope("/storage")
+        .service(handlers::storage_handler)
+        .route("/health", web::get().to(handlers::health_check))
+}
+
+pub fn mempool_routes() -> Scope {
+    web::scope("/mempool")
+        .service(handlers::mempool_handler)
+        .route("/health", web::get().to(handlers::health_check))
+}
+
+pub fn miner_routes() -> Scope {
+    web::scope("/miner")
+        .service(handlers::miner_handler)
+        .route("/health", web::get().to(handlers::health_check))
+}
+
+pub fn miner_user_routes() -> Scope {
+    web::scope("/miner_user")
+        .service(handlers::miner_user_handler)
+        .route("/health", web::get().to(handlers::health_check))
+}


### PR DESCRIPTION
# PR Description: Implement Health Check Endpoint for Node Types

## Summary of Changes
This pull request introduces a health check endpoint across multiple node types within the network. The following changes have been made:
1. Implemented the `health_check` function in `handlers.rs`.
2. Updated `routes.rs` to add the `.or(...)` block for the `health_check` handler in the routing logic for each node type: User, Storage, Mempool, Miner, and Miner+User.

## Motivation
The addition of a health check endpoint allows for better monitoring and stability of the network. It provides developers and operators insight into the operational status of various node types and improves overall system reliability.

## Relevant Context
Health checks are vital in distributed systems to ensure that each component is functioning correctly. Integrating this endpoint across all node types enables centralized health monitoring and aids in troubleshooting potential issues.

## Testing Instructions
To verify the implementation:
1. Start the server.
2. Send GET requests to the `/health` endpoint for each node type:
   - User: `/health/user`
   - Storage: `/health/storage`
   - Mempool: `/health/mempool`
   - Miner: `/health/miner`
   - Miner+User: `/health/miner_user`
   
3. Ensure that the expected health check response is received from each endpoint.

## Known Issues/Limitations
- No known issues at this time. Please report any anomalies encountered during testing for further investigation.

We appreciate any feedback on this implementation to enhance the health monitoring capabilities of our network. Thank you!